### PR TITLE
Fix level mapping

### DIFF
--- a/src/process-logs.ts
+++ b/src/process-logs.ts
@@ -95,7 +95,7 @@ export const convertLevel = (level: number | string): string => {
     return level
   }
 
-  if (level == 60) {
+  if (level >= 60) {
     return 'fatal'
   }
   if (level >= 50) {
@@ -105,13 +105,13 @@ export const convertLevel = (level: number | string): string => {
     return 'warning'
   }
   if (level >= 30) {
-    return 'log'
-  }
-  if (level >= 20) {
     return 'info'
   }
+  if (level >= 20) {
+    return 'debug'
+  }
 
-  return 'debug'
+  return 'trace'
 }
 
 interface SendLogOpts {


### PR DESCRIPTION
According to datadog [documentation](https://docs.datadoghq.com/logs/log_configuration/processors/?tab=ui#log-status-remapper), the native pino levels labels are supported. 

We just need to map correctly
https://github.com/pinojs/pino/blob/master/docs/api.md#loggerlevels-object

thanks for this lib