### PR TITLE
Update README.md - Adding ServerConf example for EU

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ const logger = pino(pinoConf, pino.transport({
         apiKeyAuth: <your datadog API key>
       }
     },
+    ddServerConf: {
+      // Note: This must match the site you use for your DataDog login - See below for more info
+      site: "datadoghq.eu"
+    }
   }
 }))
 ```


### PR DESCRIPTION
This makes it easier to setup if you are using one of the non-default servers, e.g. in Europe.