### PR TITLE
fix `setServerVariables is deprecated` warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "pino-datadog-transport",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pino-datadog-transport",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@datadog/datadog-api-client": "^1.2.0",
+        "@datadog/datadog-api-client": "^1.18.0",
         "exit-hook": "^2.2.1",
         "p-retry": "^4.6.2",
         "pino-abstract-transport": "^1.0.0"
@@ -100,20 +100,18 @@
       }
     },
     "node_modules/@datadog/datadog-api-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.2.0.tgz",
-      "integrity": "sha512-u0yeEbtipiVjQOVjbsBLbnFmmDTd7Kahpy3UcB7Vn/z5+DBRPKhE31/KWpJ9/fg04t3ZlAUYzo93IR2xUf1iww==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.18.0.tgz",
+      "integrity": "sha512-taLUl7qXP3a4m2sqVM9tbtMeUPum4yMCkdhnqsFf6n+WUq6oFpw6Ycqigdfv8Emto7QFzBF9if0lOnoC88NTpg==",
       "dependencies": {
         "@types/buffer-from": "^1.1.0",
         "@types/node": "*",
         "@types/pako": "^1.0.3",
-        "btoa": "^1.2.1",
         "buffer-from": "^1.1.2",
         "cross-fetch": "^3.1.5",
-        "durations": "^3.4.2",
-        "es6-promise": "^4.2.4",
-        "form-data": "^3.0.0",
-        "loglevel": "^1.7.1",
+        "es6-promise": "^4.2.8",
+        "form-data": "^4.0.0",
+        "loglevel": "^1.8.1",
         "pako": "^2.0.4",
         "url-parse": "^1.4.3"
       },
@@ -1110,17 +1108,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1655,14 +1642,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/durations": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/durations/-/durations-3.4.2.tgz",
-      "integrity": "sha512-V/lf7y33dGaypZZetVI1eu7BmvkbC4dItq12OElLRpKuaU5JxQstV2zHwLv8P7cNbQ+KL1WD80zMCTx5dNC4dg==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/dynamic-dedupe": {
@@ -2607,9 +2586,9 @@
       "dev": true
     },
     "node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3703,9 +3682,9 @@
       }
     },
     "node_modules/loglevel": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
-      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -5765,20 +5744,18 @@
       "dev": true
     },
     "@datadog/datadog-api-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.2.0.tgz",
-      "integrity": "sha512-u0yeEbtipiVjQOVjbsBLbnFmmDTd7Kahpy3UcB7Vn/z5+DBRPKhE31/KWpJ9/fg04t3ZlAUYzo93IR2xUf1iww==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.18.0.tgz",
+      "integrity": "sha512-taLUl7qXP3a4m2sqVM9tbtMeUPum4yMCkdhnqsFf6n+WUq6oFpw6Ycqigdfv8Emto7QFzBF9if0lOnoC88NTpg==",
       "requires": {
         "@types/buffer-from": "^1.1.0",
         "@types/node": "*",
         "@types/pako": "^1.0.3",
-        "btoa": "^1.2.1",
         "buffer-from": "^1.1.2",
         "cross-fetch": "^3.1.5",
-        "durations": "^3.4.2",
-        "es6-promise": "^4.2.4",
-        "form-data": "^3.0.0",
-        "loglevel": "^1.7.1",
+        "es6-promise": "^4.2.8",
+        "form-data": "^4.0.0",
+        "loglevel": "^1.8.1",
         "pako": "^2.0.4",
         "url-parse": "^1.4.3"
       }
@@ -6489,11 +6466,6 @@
         "picocolors": "^1.0.0"
       }
     },
-    "btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
-    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -6891,11 +6863,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "durations": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/durations/-/durations-3.4.2.tgz",
-      "integrity": "sha512-V/lf7y33dGaypZZetVI1eu7BmvkbC4dItq12OElLRpKuaU5JxQstV2zHwLv8P7cNbQ+KL1WD80zMCTx5dNC4dg=="
     },
     "dynamic-dedupe": {
       "version": "0.3.0",
@@ -7603,9 +7570,9 @@
       "dev": true
     },
     "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8378,9 +8345,9 @@
       }
     },
     "loglevel": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
-      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typescript"
   ],
   "dependencies": {
-    "@datadog/datadog-api-client": "^1.2.0",
+    "@datadog/datadog-api-client": "^1.18.0",
     "exit-hook": "^2.2.1",
     "p-retry": "^4.6.2",
     "pino-abstract-transport": "^1.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { DDTransportOptions, processLogBuilder } from './process-logs'
 
 module.exports = function (options: DDTransportOptions) {
   const configuration = client.createConfiguration(options.ddClientConf)
-  client.setServerVariables(configuration, options?.ddServerConf || {})
+  configuration.setServerVariables(options?.ddServerConf || {})
   const apiInstance = new v2.LogsApi(configuration)
 
   return build(processLogBuilder(options, apiInstance))


### PR DESCRIPTION
https://github.com/DataDog/datadog-api-client-typescript/blob/b478095fb6e4063fa3f4d9ff2980efadf3e02284/packages/datadog-api-client-common/configuration.ts#L285-L287

Added in https://github.com/DataDog/datadog-api-client-typescript/releases/tag/v1.16.0

Closes #17 